### PR TITLE
fix(rules): explicitly import rules to trigger side effects

### DIFF
--- a/src/autoload.ts
+++ b/src/autoload.ts
@@ -1,4 +1,3 @@
 import { loadAllRules } from './loader.js';
-import './rules/index.js';
 
 loadAllRules();

--- a/src/loader.ts
+++ b/src/loader.ts
@@ -14,6 +14,7 @@ import type {
   TechMatcher,
 } from './types/rule.js';
 import type { AllowedKeys } from './types/techs.js';
+import './rules/index.js';
 
 export const rulesTechs: TechMatcher[] = [];
 export const rulesExtensions: ExtensionMatcher[] = [];


### PR DESCRIPTION
This adds an explicit import for the rules index file, to trigger the registration side effects of each rule being imported. Each rule file module runs `register` - and unless imported, that registration will not happen.

This was already happening in the CLI, as it uses `autoload.ts` - which contained an explicit import for the rules module index. However, when using the library programmatically, `rules.loadAll` would not have any registered rules to load.

## Work around

You can work around this issue at the moment by using `import '@specfy/stack-analyser/dist/autoload.js'`, or including `import '@specfy/stack-analyser/dist/rules/index.js'` before running `rules.loadAll`.

```ts
import '@specfy/stack-analyser/dist/autoload.js'

// or

import { rules } from '@specfy/stack-analyser'
import '@specfy/stack-analyser/dist/rules/index.js'

rules.loadAll()
```