### PR TITLE
fix(rules): add Wasp

### DIFF
--- a/src/rules/js/index.ts
+++ b/src/rules/js/index.ts
@@ -33,4 +33,5 @@ import './tailwind.js';
 import './typescript.js';
 import './vite.js';
 import './vue.js';
+import './wasp.js';
 import './webpack.js';

--- a/src/rules/js/wasp.ts
+++ b/src/rules/js/wasp.ts
@@ -1,0 +1,8 @@
+import { register } from '../../register.js';
+
+register({
+  tech: 'wasp',
+  name: 'Wasp',
+  type: 'framework',
+  files: ['main.wasp'],
+});

--- a/src/rules/js/wasp.ts
+++ b/src/rules/js/wasp.ts
@@ -4,5 +4,5 @@ register({
   tech: 'wasp',
   name: 'Wasp',
   type: 'framework',
-  files: ['main.wasp'],
+  files: ['main.wasp', 'main.wasp.ts'],
 });

--- a/src/types/techs.ts
+++ b/src/types/techs.ts
@@ -481,6 +481,7 @@ export type AllowedKeys =
   | 'victoriametrics'
   | 'vite'
   | 'vue'
+  | 'wasp'
   | 'webflow'
   | 'webpack'
   | 'wiz'


### PR DESCRIPTION
Adding [Wasp framework](https://wasp-lang.dev/) to the list of registered frameworks. I added it in the js folder because we're combining React and Node.js with Prisma for the database.

